### PR TITLE
Auto-resolve reference assemblies from framework directory

### DIFF
--- a/EmpireCompiler/Core/Common.cs
+++ b/EmpireCompiler/Core/Common.cs
@@ -31,5 +31,19 @@ namespace EmpireCompiler.Core
             Net48,
             NetCore31
         }
+
+        public static string GetAssemblyReferenceDirectory(DotNetVersion version)
+        {
+            return version switch
+            {
+                DotNetVersion.Net35 => EmpireAssemblyReferenceNet35Directory,
+                DotNetVersion.Net40 => EmpireAssemblyReferenceNet40Directory,
+                DotNetVersion.Net45 => EmpireAssemblyReferenceNet45Directory,
+                DotNetVersion.Net46 => EmpireAssemblyReferenceNet46Directory,
+                DotNetVersion.Net47 => EmpireAssemblyReferenceNet47Directory,
+                DotNetVersion.Net48 => EmpireAssemblyReferenceNet48Directory,
+                _ => throw new System.ArgumentException($"No assembly reference directory for {version}")
+            };
+        }
     }
 }

--- a/EmpireCompiler/Models/Module/AgentTask.cs
+++ b/EmpireCompiler/Models/Module/AgentTask.cs
@@ -4,6 +4,8 @@ using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.IO;
 using System.Linq;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
 
 using EmpireCompiler.Core;
 
@@ -197,22 +199,11 @@ namespace EmpireCompiler.Models.Agents
                         })
                 );
             });
-            List<Compiler.Reference> references = new List<Compiler.Reference>();
-            this.ReferenceSourceLibraries.ToList().ForEach(RSL =>
-            {
-                references.AddRange(
-                    RSL.ReferenceAssemblies.Where(RA => RA.DotNetVersion == dotnetVersion).Select(RA =>
-                    {
-                        return new Compiler.Reference { File = Common.EmpireAssemblyReferenceDirectory + RA.Location, Framework = dotnetVersion, Enabled = true };
-                    })
-                );
-            });
-            references.AddRange(
-                this.ReferenceAssemblies.Where(RA => RA.DotNetVersion == dotnetVersion).Select(RA =>
-                {
-                    return new Compiler.Reference { File = Common.EmpireAssemblyReferenceDirectory + RA.Location, Framework = dotnetVersion, Enabled = true };
-                })
-            );
+            string frameworkDir = Common.GetAssemblyReferenceDirectory(dotnetVersion);
+            List<Compiler.Reference> references = Directory.GetFiles(frameworkDir, "*.dll")
+                .Where(IsManagedFrameworkAssembly)
+                .Select(dll => new Compiler.Reference { File = dll, Framework = dotnetVersion, Enabled = true })
+                .ToList();
 
             File.WriteAllBytes(this.OutputPath,
                 Compiler.Compile(new Compiler.CsharpFrameworkCompilationRequest
@@ -229,6 +220,49 @@ namespace EmpireCompiler.Models.Agents
                     Optimize = !this.ReferenceSourceLibraries.Select(RSL => RSL.Name).Contains("Seatbelt")
                 })
             );
+        }
+
+        private static bool IsManagedFrameworkAssembly(string dllPath)
+        {
+            try
+            {
+                using var stream = File.OpenRead(dllPath);
+                using var peReader = new PEReader(stream);
+                if (!peReader.HasMetadata)
+                {
+                    return false;
+                }
+
+                var metadataReader = peReader.GetMetadataReader();
+                if (!metadataReader.IsAssembly)
+                {
+                    return false;
+                }
+
+                // Exclude .NET Standard facade assemblies (e.g. System.Buffers, System.Memory)
+                // that reference System.Runtime instead of mscorlib, as they cause CS0012 errors
+                // when System.Runtime.dll is not present in the reference set.
+                bool refsMscorlib = false;
+                bool refsSysRuntime = false;
+                foreach (var handle in metadataReader.AssemblyReferences)
+                {
+                    var name = metadataReader.GetString(metadataReader.GetAssemblyReference(handle).Name);
+                    if (name == "mscorlib")
+                    {
+                        refsMscorlib = true;
+                    }
+                    else if (name == "System.Runtime")
+                    {
+                        refsSysRuntime = true;
+                    }
+                }
+
+                return refsMscorlib || !refsSysRuntime;
+            }
+            catch
+            {
+                return false;
+            }
         }
     }
 

--- a/EmpireCompiler/Models/Module/TaskComponents.cs
+++ b/EmpireCompiler/Models/Module/TaskComponents.cs
@@ -303,7 +303,7 @@ namespace EmpireCompiler.Models.Agents
         public string Location { get; set; }
         public ImplantLanguage Language { get; set; } = ImplantLanguage.CSharp;
         public List<Common.DotNetVersion> CompatibleDotNetVersions { get; set; }
-        public List<SerializedReferenceAssembly> ReferenceAssemblies { get; set; }
-        public List<SerializedEmbeddedResource> EmbeddedResources { get; set; }
+        public List<SerializedReferenceAssembly> ReferenceAssemblies { get; set; } = new List<SerializedReferenceAssembly>();
+        public List<SerializedEmbeddedResource> EmbeddedResources { get; set; } = new List<SerializedEmbeddedResource>();
     }
 }


### PR DESCRIPTION
Remove the need to manually specify ReferenceAssemblies in task YAMLs. The compiler now auto-discovers all valid managed assemblies from the target framework's AssemblyReferences directory, filtering out native DLLs, .NET modules, and .NET Standard facade assemblies.