### PR TITLE
Update Sharpire submodule to 7.0-dev branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -40,6 +40,7 @@
 [submodule "EmpireCompiler/Data/ReferenceSourceLibraries/Sharpire"]
 	path = EmpireCompiler/Data/ReferenceSourceLibraries/Sharpire
 	url = https://github.com/BC-SECURITY/Sharpire.git
+	branch = 7.0-dev
 [submodule "EmpireCompiler/Data/ReferenceSourceLibraries/ThreadlessInject"]
 	path = EmpireCompiler/Data/ReferenceSourceLibraries/ThreadlessInject
 	url = https://github.com/Cx01N/ThreadlessInject.git


### PR DESCRIPTION
## Summary
- Updates Sharpire submodule from `master` (`4b5e905`) to `7.0-dev` (`e5abab3`)
- Adds `branch = 7.0-dev` tracking to `.gitmodules`

## Test plan
- [ ] Verify `git submodule update --init --recursive` checks out the correct Sharpire branch
- [ ] Verify builds succeed with the updated Sharpire source

🤖 Generated with [Claude Code](https://claude.com/claude-code)